### PR TITLE
Resolve absolute paths to js root

### DIFF
--- a/src/compiler.js
+++ b/src/compiler.js
@@ -288,6 +288,13 @@ class Compiler extends EventEmitter {
 				require.resolve('./dev-refresh-client'),
 				this.skipWordpress ? this.siteRoot : this.assetPath+'/js/index.js'
 			],
+			resolve: {
+				extensions: ['.js'],
+				modules: [
+					path.resolve('./assets-src/js'),
+					path.resolve('./node_modules')
+				]
+			},
 			output: {
 				path: path.join(this.themePath, '/assets-built/js'),
 				filename: 'bundle.js'
@@ -342,6 +349,13 @@ class Compiler extends EventEmitter {
 			entry: [
 				this.skipWordpress ? this.siteRoot : this.assetPath+'/js/index.js'
 			],
+			resolve: {
+				extensions: ['.js'],
+				modules: [
+					path.resolve('./assets-src/js'),
+					path.resolve('./node_modules')
+				]
+			},
 			output: {
 				path: path.join(this.themePath, '/assets-built/js'),
 				filename: 'bundle.js'


### PR DESCRIPTION
Added a "resolve" property to the webpack compiler to allow for absolute import paths:

e.g. : 

`import something from 'libs/something';` 

instead of having to run the tree like:

`import something from '../../libs/something';`